### PR TITLE
global hook is need for view_hooks

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -32,3 +32,5 @@ end
 
 # Require the GTT Assistant library
 require ::File.expand_path('lib/redmine_gtt_assistant', __dir__)
+# Global hooks
+require File.expand_path('../lib/redmine_gtt_assistant/view_hooks', __FILE__)


### PR DESCRIPTION
Changes proposed in this pull request:
- global hook(force load) is need for view_hooks

env:
```
Environment:
  Redmine version                5.0.5.stable
  Ruby version                   3.1.3-p185 (2022-11-24) [arm64-darwin22]
  Rails version                  6.1.7.2
  Environment                    development
  Database adapter               PostGIS
  Mailer queue                   ActiveJob::QueueAdapters::AsyncAdapter
  Mailer delivery                smtp
Redmine settings:
  Redmine theme                  Default
SCM:
  Git                            2.37.1
  Filesystem                     
Redmine plugins:
  redmine_gtt                    4.3.1
  redmine_gtt_assistant          0.1.0
  redmine_gtt_fiware             0.1.0
  redmine_gtt_smash              2.0.0
```


@gtt-project/maintainer
